### PR TITLE
feat: Support for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "NMapsGeometry",
+    products: [
+        .library(
+            name: "NMapsGeometry",
+            targets: ["NMapsGeometry"]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "NMapsGeometry",
+            path: "framework/NMapsGeometry.xcframework"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# NMapsGeometry
+
+## Installation
+
+### Swift Package Manager
+
+To integrate `NMapsGeometry` into your Xcode project using Swift Package Manager, follow these steps
+
+- Navigate to the "File" menu and select "Add Packages...".
+- Enter "https://github.com/navermaps/NMapsGeometry" as the package repository URL.


### PR DESCRIPTION
## 배경
NMapsMap에서 SPM 지원을 위한 PR을 준비 중에, NMapsGeometry에 대한 의존성을 제대로 설정하지 않으면 헤더를 찾지 못하는 문제를 확인 했습니다. 이를 해결하기 위해 현재 저장소에 SPM을 지원하는 기능을 추가했습니다.

## 변경내역
- Package.swift 파일을 추가하여 Swift Package Manager를 지원하도록 설정하였습니다.
- 설치 가이드 문서를 추가했습니다.

## 테스트 된 내용
임시로 [NMapsMap Package.swift](https://github.com/topkim993/NMapsMap/blob/master/Package.swift)를 작성하고, 테스트 앱에서 Native SPM 및 Tuist Dependency를 통해 의존성 설정 및 빌드를 체크했습니다.